### PR TITLE
Added set_newline to fix TLS email sending

### DIFF
--- a/application/controllers/auth.php
+++ b/application/controllers/auth.php
@@ -476,6 +476,7 @@ class Auth extends CI_Controller
 	function _send_email($type, $email, &$data)
 	{
 		$this->load->library('email');
+		$this->email->set_newline("\r\n");
 		$this->email->from($this->config->item('webmaster_email', 'tank_auth'), $this->config->item('website_name', 'tank_auth'));
 		$this->email->reply_to($this->config->item('webmaster_email', 'tank_auth'), $this->config->item('website_name', 'tank_auth'));
 		$this->email->to($email);


### PR DESCRIPTION
I added $this->email->set_newline("\r\n"); to the Auth::_send_email controller method so that emails can be sent of TLS aka ssl://somemailserver.tld
